### PR TITLE
tageja kehitetty. Toiminnallisuus kasassa, validointi ja testaus vajaa

### DIFF
--- a/application/api/views.py
+++ b/application/api/views.py
@@ -26,14 +26,15 @@ def tip_create_new():
 
     tip = Tip(data["title"].strip(), data["url"].strip())
     
-    for tagName in data["tags"]:
-        # oletus että front palauttaa tagin nimen tagina
-        tag = Tag.query.filter(Tag.name == tagName).first()
-        if tag is None:
-            tag = Tag(tagName)
-            db.session().add(tag)
-        tip.tags.append(tag)
-
+    if 'tags' in data: # käsitellään tagit vain jos attribuutti "tags" datassa
+        for tagName in data["tags"]:
+            # oletus että front palauttaa tagin nimen tagina
+            tag = Tag.query.filter(Tag.name == tagName).first()
+            if tag is None:
+                tag = Tag(tagName)
+                db.session().add(tag)
+            tip.tags.append(tag)
+    
     db.session().add(tip)
     db.session().commit()
 
@@ -42,14 +43,14 @@ def tip_create_new():
 
 #metodi vinkin poistamiseen. Laitoin redirectin listaukseen. Sitä tietenkin voi miettiä, mihin sen deletoinnin jälkeen 
 #haluaa vievän. Päällepäin tämä näytti toimivan.
-@api.route("/tips/<tip_id>/remove", methods = ["POST"])
+@api.route("/tips/<tip_id>", methods = ["DELETE"]) # metodi DELETE ja REST-käytännön mukaan kutsun route: /api/tips/{tip_id}
 def tip_remove(tip_id):
 
-    tip = Tip.query.get(tip_id)
+    tip = Tip.query.get_or_404(tip_id) # sama kuin get, mutta palauttaa 404 jos tietuetta ei löydy
     db.session().delete(tip)
     db.session().commit()
 
-    return redirect(url_for("tip_listing"))
+    return Response(status=204)
 
 #Tag-taulun testaamista varten tehty metodi
 @api.route('/tags', methods=['GET'])

--- a/application/models.py
+++ b/application/models.py
@@ -1,6 +1,14 @@
 from . import db
 
 
+#yhdistetaulu tipeistä ja tageista. Huomio itselleni ja miksei muillekin:
+# Jotta Tip-luokassa voidaan viitata tähän yhteystauluun, yhteystaulun täytyy olla jo luotuna. Järjestyksellä on merkitystä ja sen
+# takia tämä tiptags-taulu on ylimpänä. Yhteystaulun voi siis luoda ennen classeja, mutta ei toisinpäin.
+tiptags = db.Table('tiptags',
+    db.Column('tag_id', db.Integer, db.ForeignKey('tag.id'), primary_key=True),
+    db.Column('tip_id', db.Integer, db.ForeignKey('tip.id'), primary_key=True)
+)
+
 class Tip(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     # Halutaanko näitä allaolevia hakutuloksia somistamaan? 
@@ -12,9 +20,9 @@ class Tip(db.Model):
     url = db.Column(db.String(144), nullable=True)
     # puhetta oli, että lukuvinkin voisi merkitä myös luetuksi.
     read = db.Column(db.Boolean, default=False, nullable=False)
-    
-    #Tagit voi toteuttaa joko monen suhde moneen tai 1 suhde moneen tauluna. Monen suhde moneen mallissa tag ei ole tässä taulussa vaan on olemassa erillinen 
-    #linkkitaulu niille. 
+    #Tipin viittaus yhteystauluun. Viittauksen sijainti on Tipissä, koska tipin perusteella tagien näyttäminen on todennäköisempää kuin toisinpäin
+    tags = db.relationship("Tag", secondary = tiptags, lazy = 'subquery',
+    backref = db.backref('users', lazy = True))
 
     def __init__(self, title, url):
         self.title = title
@@ -27,17 +35,27 @@ class Tip(db.Model):
             'id' : self.id,
             'title' : self.title,
             'url' : self.url,
-            'read' : self.read
+            'read' : self.read,
+            'tags' : [tag.name for tag in self.tags]
+
         }    
 
 # uusi tag-luokka. Täytyy tarkistaa, kuuluiko tagillekin aikaleima
 class Tag(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(144), nullable=False)	
+    name = db.Column(db.String(144), nullable=False)
+
+    #Tagillekin init-metodi
+    def __init__(self, name):
+        self.name = name
+    
+
+    #serialize-metodi tagille
+    @property
+    def serialize(self):
+        return {
+            'id' : self.id,
+            'name' : self.name
+        }
 	
     
-#yhdistetaulu tipeistä ja tageista.
-tiptags = db.Table('tiptags',
-    db.Column('tag_id', db.Integer, db.ForeignKey('tag.id'), primary_key=True),
-    db.Column('tip_id', db.Integer, db.ForeignKey('tip.id'), primary_key=True)
-)

--- a/curltest.md
+++ b/curltest.md
@@ -13,3 +13,5 @@ curl -d '{"name": "Testinimi", "link": "http://www.google.com"}' -H "Content-Typ
 
 
 curl -d '{"title": "Testinimi", "url": "http://www.google.com"}' -H "Content-Type: application/json" http://localhost:5000/api/tips
+
+curl -d '{"title": "Testinimi", "url": "http://www.google.com", "tags": ["kissa","cat","feline"]}' -H "Content-Type: application/json" http://localhost:5000/api/tips


### PR DESCRIPTION
models.py : Tietokannassa Tageille on lisätty serialize ja init-metodit. Tip-tauluun on lisätty yhteys tiptagsiin. Tipin serialize-metodiin on lisätty lista tageja. Tietokannassa myös tiptags-taulun sijainti muutettu oikeasti toimivaksi.

views.py: Uuden vinkin lisäämistä on muokattu siten, että frontista tulevaa taglistan sisältöä voisi lisätä tietokantaan. on tehtynä myös metodi, jonka avulla Tag-taulun toimivuutta testattiin.

Eli summa summarum: tagilistaukseen liittyvää toiminnallisuutta.

Validointia ei ole, mutta hieman manuaalista testausta tehty. Curl-dokkari päivitetty. 

Ja opettelen edelleen pull requestien tekemistä...hyvää pääsiäistä.