### PR TITLE
vinkkien haku tagien perusteella ja lukemattomien vinkkien listaus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 db/
 *.db
 htmlcov
+geckodriver.log
+*.pyc

--- a/application/api/views.py
+++ b/application/api/views.py
@@ -58,3 +58,24 @@ def tag_listing():
     tags = Tag.query.all()
     return Response(json.dumps([tag.serialize for tag in tags]), status=200, mimetype='application/json; charset=utf-8')
 
+#22.4, 3. sprintti
+#Tipit yhden tagin perusteella
+#Ymmärsin että yhden tagin perusteella, mutta tajusin vasta myöhemmin, että pitikö tämän olla monella tagilla toimiva, eli pitäisikö tag_id:stä olla lista.
+@api.route('tags/<tag_name>', methods=['GET'])
+def tips_for_tag(tag_name):
+
+    tag = Tag.query.filter(Tag.name==tag_name).first()
+    # koska relaatio on backreffillä olemassa tietokannassa, pitäisi olla mahdollista hakea
+    # tags = tip.tags ja vastaavasti:
+    tips = tag.tips
+ 
+    return Response(json.dumps([tip.serialize for tip in tips]), status=200, mimetype='application/json; charset=utf-8')
+
+#22.4 3.sprintti
+#Vinkit, joita ei ole vielä luettu
+@api.route('tips/nonread', methods=['GET'])
+def tips_non_read():
+
+    tips = Tip.query.filter(Tip.read==False).all()
+
+    return Response(json.dumps([tip.serialize for tip in tips]), status=200, mimetype='application/json; charset=utf-8')

--- a/application/api/views.py
+++ b/application/api/views.py
@@ -102,6 +102,9 @@ def tips_is_read(tip_id):
 def tip_update(tip_id):
     data = request.get_json()
 
+    if 'title' in data and len(data['title']) == 0:
+        return Response(json.dumps({'error': 'title cannot be left empty'}), status=400, mimetype='application/json')
+
     db.session.query(Tip).filter(Tip.id == tip_id).update(data)
     db.session().commit()
 

--- a/application/api/views.py
+++ b/application/api/views.py
@@ -94,46 +94,20 @@ def tips_is_read(tip_id):
     tip.readAt = datetime.now()
     db.session().commit()
 
-    return Response(json.dumps(tip.serialize), status=201, mimetype='application/json')
+    return Response(json.dumps(tip.serialize), status=200, mimetype='application/json')
 
 #24.4   3 sprintti
 #Vinkin muokkaaminen
-@api.route('tips/<tip_id>/update', methods=['POST'])
+@api.route('tips/<tip_id>', methods=['PUT'])
 def tip_update(tip_id):
-
-    tip = Tip.query.get(tip_id)
     data = request.get_json()
 
-    #Jos muokkauksessa jää otsikko pois.
-    if "title" not in data or not data["title"]:
-        return Response(json.dumps({'error': 'title must be provided'}), status=400, mimetype='application/json')
-
-    #muokatun tiedon laittaminen talteen.
-    tip.title = data["title"].strip()
-    tip.url = data["url"].strip()
-    
-    string_read = data["read"]
-
-    if string_read.lower() == 'false':
-        tip.read=False
-
-    if string_read.lower() == 'true':
-        tip.read = True
-
-
-        #copypaste create-metodista. Onko toiminnassa oikeastaan eroa?        
-    if 'tags' in data: # käsitellään tagit vain jos attribuutti "tags" datassa
-        for tagName in data["tags"]:
-            # oletus että front palauttaa tagin nimen tagina
-            tag = Tag.query.filter(Tag.name == tagName).first()
-            if tag is None:
-                tag = Tag(tagName)
-                db.session().add(tag)
-            tip.tags.append(tag)
-
+    db.session.query(Tip).filter(Tip.id == tip_id).update(data)
     db.session().commit()
 
-    return Response(json.dumps(tip.serialize), status=201, mimetype='application/json')
+    tip = Tip.query.get(tip_id)
+
+    return Response(json.dumps(tip.serialize), status=200, mimetype='application/json')
 
 
 #24.4    3.sprintti

--- a/application/api/views.py
+++ b/application/api/views.py
@@ -2,6 +2,7 @@ from flask import Response, request, json, jsonify, redirect, url_for, abort, cu
 from ..models import Tip, Tag
 from application import db
 from . import api # tämä on blueprint ks https://flask.palletsprojects.com/en/1.1.x/blueprints/
+from datetime import datetime
 
 @api.route('/tips', methods=['GET'])
 def tip_listing():
@@ -73,9 +74,75 @@ def tips_for_tag(tag_name):
 
 #22.4 3.sprintti
 #Vinkit, joita ei ole vielä luettu
-@api.route('tips/nonread', methods=['GET'])
+@api.route('tips/unread', methods=['GET'])
 def tips_non_read():
 
     tips = Tip.query.filter(Tip.read==False).all()
 
     return Response(json.dumps([tip.serialize for tip in tips]), status=200, mimetype='application/json; charset=utf-8')
+
+
+#24.4   3 sprintti
+#Vinkin merkkaaminen luetuksi
+# 
+@api.route('tips/<tip_id>/read', methods=['POST'])
+def tips_is_read(tip_id):
+    
+    tip = Tip.query.get(tip_id)
+    tip.read = True
+    #datetimen huono puoli on se, että se ottaa ajan sieltä, missä serveri sijaitsee. Herokun serveri tais olla jenkeissä.
+    tip.readAt = datetime.now()
+    db.session().commit()
+
+    return Response(json.dumps(tip.serialize), status=201, mimetype='application/json')
+
+#24.4   3 sprintti
+#Vinkin muokkaaminen
+@api.route('tips/<tip_id>/update', methods=['POST'])
+def tip_update(tip_id):
+
+    tip = Tip.query.get(tip_id)
+    data = request.get_json()
+
+    #Jos muokkauksessa jää otsikko pois.
+    if "title" not in data or not data["title"]:
+        return Response(json.dumps({'error': 'title must be provided'}), status=400, mimetype='application/json')
+
+    #muokatun tiedon laittaminen talteen.
+    tip.title = data["title"].strip()
+    tip.url = data["url"].strip()
+    
+    string_read = data["read"]
+
+    if string_read.lower() == 'false':
+        tip.read=False
+
+    if string_read.lower() == 'true':
+        tip.read = True
+
+
+        #copypaste create-metodista. Onko toiminnassa oikeastaan eroa?        
+    if 'tags' in data: # käsitellään tagit vain jos attribuutti "tags" datassa
+        for tagName in data["tags"]:
+            # oletus että front palauttaa tagin nimen tagina
+            tag = Tag.query.filter(Tag.name == tagName).first()
+            if tag is None:
+                tag = Tag(tagName)
+                db.session().add(tag)
+            tip.tags.append(tag)
+
+    db.session().commit()
+
+    return Response(json.dumps(tip.serialize), status=201, mimetype='application/json')
+
+
+#24.4    3.sprintti
+# Vinkin hakeminen otsikolla
+@api.route('tips/title/<tip_title>', methods=['GET'])
+def tip_title_search(tip_title):
+    #huom! tip_title on joko title tai osa titleä.    
+    # tämä format metodi muuttaa metodin inputtina saaman tip_titlen käytännössä %{ tip_title }%,joka laitetaan queryyn sisään. 
+    tip_title =  "%{}%".format(tip_title)    
+    tips_selected = Tip.query.filter(Tip.title.like(tip_title)).all()
+
+    return Response(json.dumps([tip.serialize for tip in tips_selected]), status=200, mimetype='application/json; charset=utf-8')

--- a/application/models.py
+++ b/application/models.py
@@ -17,8 +17,10 @@ class Tip(db.Model):
     #vinkin nimi ja linkki on String-muodossa
     title = db.Column(db.String(144), nullable=False)
     url = db.Column(db.String(144), nullable=True)
-    # puhetta oli, että lukuvinkin voisi merkitä myös luetuksi.
+    # lukuvinkin luettuus, default on lukematon eli false
     read = db.Column(db.Boolean, default=False, nullable=False)
+    # ajankohta, milloin on luettu. lisätty 24.4
+    readAt = db.Column(db.DateTime, default=None)
     #Tipin viittaus yhteystauluun. Viittauksen sijainti on Tipissä, koska tipin perusteella tagien näyttäminen on todennäköisempää kuin toisinpäin
     tags = db.relationship("Tag", secondary = tiptags, lazy = 'subquery',
     backref = db.backref('tips', lazy = True))
@@ -37,8 +39,12 @@ class Tip(db.Model):
             'read' : self.read,
             'tags' : [tag.name for tag in self.tags],
             'createdAt': self.date_created,
-            'read':self.read
-        }    
+            'read':self.read,
+            'readAt':self.readAt
+        }
+
+        
+
 
 # uusi tag-luokka. Täytyy tarkistaa, kuuluiko tagillekin aikaleima
 class Tag(db.Model):

--- a/application/models.py
+++ b/application/models.py
@@ -21,7 +21,7 @@ class Tip(db.Model):
     read = db.Column(db.Boolean, default=False, nullable=False)
     #Tipin viittaus yhteystauluun. Viittauksen sijainti on Tipissä, koska tipin perusteella tagien näyttäminen on todennäköisempää kuin toisinpäin
     tags = db.relationship("Tag", secondary = tiptags, lazy = 'subquery',
-    backref = db.backref('users', lazy = True))
+    backref = db.backref('tips', lazy = True))
 
     def __init__(self, title, url):
         self.title = title
@@ -36,13 +36,15 @@ class Tip(db.Model):
             'url' : self.url,
             'read' : self.read,
             'tags' : [tag.name for tag in self.tags],
-            'createdAt': self.date_created
+            'createdAt': self.date_created,
+            'read':self.read
         }    
 
 # uusi tag-luokka. Täytyy tarkistaa, kuuluiko tagillekin aikaleima
 class Tag(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(144), nullable=False)
+    
 
     #Tagillekin init-metodi
     def __init__(self, name):

--- a/curltest.md
+++ b/curltest.md
@@ -14,4 +14,11 @@ curl -d '{"name": "Testinimi", "link": "http://www.google.com"}' -H "Content-Typ
 
 curl -d '{"title": "Testinimi", "url": "http://www.google.com"}' -H "Content-Type: application/json" http://localhost:5000/api/tips
 
+## viikko3
+
 curl -d '{"title": "Testinimi", "url": "http://www.google.com", "tags": ["kissa","cat","feline"]}' -H "Content-Type: application/json" http://localhost:5000/api/tips
+
+curl  -X POST http://localhost:5000/api/tips/1/read
+
+
+curl -d '{"title": "Testinimi", "url": "http://www.google.com", "tags": ["kissa","cat","feline"],"read":"true"}' -H "Content-Type: application/json" http://localhost:5000/api/tips/1/update


### PR DESCRIPTION
Eli tässä on nyt 2 metodia bäkkärille(ja jotain pientä muutosta niiden toimimiseksi)

Metodit on kommentoitu views.py:hyn 22.4 ja 3.sprintti merkinnöillä.

Ensimmäinen metodi "tips_for_tags" hakee lukuvinkkejä tagin perusteella.
Toiminta perustuu Tip taulussa määriteltyyn relaatioon, jonka backreffin perusteella pitäisi toimia monen suhde moneen -mallintaminen molempiin suuntiin. Oman pikaisen tarkastelun perusteella tämä näytti toimivan kuten sql-alchemyn perusoppaissa väitetään.

Toisena on metodi "tips_non_read" joka hakee kaikki sellaiset lukuvinkit, joiden read -kenttä on False. Myös tämä näytti pikaisella tarkastelulla ihan toimivalta metodilta.

Eli saldona on 2 listausta seuraavaan sprinttiin.





